### PR TITLE
Adjust language on readiness probes

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -336,9 +336,9 @@ For example, an application might need to load large data or configuration
 files during startup, or depend on external services after startup.
 In such cases, you don't want to kill the application,
 but you don't want to send it requests either. Kubernetes provides
-readiness probes to detect and mitigate these situations. A pod with containers
-reporting that they are not ready does not receive traffic through Kubernetes
-Services.
+readiness probes to detect and mitigate these situations. A pod with any of it's 
+containers reporting that they are not ready does not receive traffic through
+Kubernetes Services.
 
 {{< note >}}
 Readiness probes runs on the container during its whole lifecycle.


### PR DESCRIPTION
Changes the sentence describing the behaviour between readiness probes and Kubernetes Services to be less vague. It now specifies that if any containers are reporting not ready, the Pod is removed from the Service. Prior to this change, the line could be interpreted as if all of its containers report not ready.